### PR TITLE
Show Atheris+Hypothesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 atheris.egg-info
+.hypothesis

--- a/README.md
+++ b/README.md
@@ -255,3 +255,26 @@ def ConsumeBool()
 
 Consume either `True` or `False`.
 
+
+### Use with Hypothesis
+
+The [Hypothesis library for property-based testing](https://hypothesis.readthedocs.io/)
+is also useful for writing fuzz harnesses.  As well as a great library of "strategies"
+which describe the inputs to generate, using Hypothesis makes it trivial to reproduce
+failures found by the fuzzer - including automatically finding a minimal reproducing
+input.  For example:
+
+```
+import atheris
+from hypothesis import given, strategies as st
+
+@given(st.from_regex(r"\w+!?", fullmatch=True))
+def test(string):
+  assert string != "bad"
+
+atheris.Setup(sys.argv, test.hypothesis.fuzz_one_input)
+atheris.Fuzz()
+```
+
+[See here for more details](https://hypothesis.readthedocs.io/en/latest/details.html#use-with-external-fuzzers),
+or [here for what you can generate](https://hypothesis.readthedocs.io/en/latest/data.html).

--- a/example_fuzzers/json_fuzzer/hypothesis_structured_fuzzer.py
+++ b/example_fuzzers/json_fuzzer/hypothesis_structured_fuzzer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+# Copyright 2020 Zac Hatfield-Dodds
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This fuzzer is an example harness using Hypothesis for structured inputs.
+
+It would be possible, though more difficult, to write this test in terms
+of Atheris' `FuzzedDataProvider` instead of Hypothesis strategies.
+
+As well as defining structured inputs however, the call to
+`test_ujson_roundtrip()` will replay, deduplicate, and minimize any known
+failing examples from previous runs - which is great when debugging.
+Hypothesis uses a separate cache to Atheris/LibFuzzer seeds, so this is
+strictly complementary to your traditional fuzzing workflow.
+
+For more details on Hypothesis, see:
+https://hypothesis.readthedocs.io/en/latest/data.html
+https://hypothesis.readthedocs.io/en/latest/details.html#use-with-external-fuzzers
+"""
+
+import sys
+import atheris
+import ujson
+from hypothesis import given, strategies as st
+
+# We could define all these inline within the call to @given(),
+# but it's a bit easier to read if we name them here instead.
+JSON_ATOMS = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-(2 ** 63), max_value=2 ** 63 - 1),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(),
+)
+JSON_OBJECTS = st.recursive(
+    base=JSON_ATOMS,
+    extend=lambda inner: st.lists(inner) | st.dictionaries(st.text(), inner),
+)
+UJSON_ENCODE_KWARGS = {
+    "ensure_ascii": st.booleans(),
+    "encode_html_chars": st.booleans(),
+    "escape_forward_slashes": st.booleans(),
+    "sort_keys": st.booleans(),
+    "indent": st.integers(0, 20),
+}
+
+
+@given(obj=JSON_OBJECTS, kwargs=st.fixed_dictionaries(UJSON_ENCODE_KWARGS))
+def test_ujson_roundtrip(obj, kwargs):
+    """Check that all JSON objects round-trip regardless of other options."""
+    assert obj == ujson.decode(ujson.encode(obj, **kwargs))
+
+
+if __name__ == "__main__":
+    # Replay, deduplicate, and minimize any failures from previous runs:
+    test_ujson_roundtrip()
+
+    # If that passed, we use Atheris to provide the inputs to our test:
+    atheris.Setup(sys.argv, test_ujson_roundtrip.hypothesis.fuzz_one_input)
+    atheris.Fuzz()


### PR DESCRIPTION
Hypothesis, the property-based testing library, has great support for external fuzzers - while making it easy to develop fuzz harnesses.  We can also automatically replay and minimize failing examples found by the fuzzer, which is a lovely debugging workflow :grin: 

I know that (an old version of) Hypothesis is used internally at Google, and I've been looking forward to this since @inferno-chromium mentioned a Python fuzzer was in the works in https://github.com/google/oss-fuzz/issues/4121.  My PhD is about how to upgrade familiar test tools and workflows with the power of fuzzing (among other tricks), and Atheris looks like an awesome upgrade to the Python ecosystem.  Thanks for open-sourcing it!

*(final note: I haven't fuzzed my example script for long, so Atheris may or may not find `ujson` bugs if left running)*