### PR TITLE
[Feature] Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,11 @@ RUN set -eux; \
         llvm-${LLVM_VERSION} && \
     CLANG_BIN="/usr/lib/llvm-12/bin/clang" pip install atheris hypothesis && \
     rm -rf /var/lib/apt/lists/*
+
+# Build from the sources
+# WORKDIR /usr/src/atheris
+# COPY . .
+# RUN set -eux; \
+#     CLANG_BIN="/usr/lib/llvm-12/bin/clang"  pip install -e .
+### Test build from sources
+###  python example_fuzzers/fuzzing_example.py 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,16 @@ RUN set -eux; \
         clang-${LLVM_VERSION} \
         lld-${LLVM_VERSION} \
         llvm-${LLVM_VERSION} && \
-    CLANG_BIN="/usr/lib/llvm-12/bin/clang" pip install atheris hypothesis && \
+    chmod -f +x /usr/lib/llvm-${LLVM_VERSION}/bin/* && \
+    update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-${LLVM_VERSION} 999 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 999 && \
+    CLANG_BIN="/usr/bin/clang" pip install atheris hypothesis && \
     rm -rf /var/lib/apt/lists/*
 
 # Build from the sources
 # WORKDIR /usr/src/atheris
 # COPY . .
 # RUN set -eux; \
-#     CLANG_BIN="/usr/lib/llvm-12/bin/clang"  pip install -e .
+#     CLANG_BIN="/usr/bin/clang"  pip install -e .
 ### Test build from sources
-###  python example_fuzzers/fuzzing_example.py 
+###  python example_fuzzers/fuzzing_example.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,31 @@
-FROM python:3.8-buster
-# Example command:
+# Copyright 2020 Valeriy Soloviov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile extending the generic Python image with atheris inside.
+
+# To build the image, it is necessary that docker build be invoked from the
+# parent folder of this file.
+# Example container execution command:
+#
 # $ git clone https://github.com/google/atheris.git
 # $ cd atheris
-# $ sudo docker build -t local/atheris .
-# $ sudo docker run -ti --rm local/atheris 
+# $ docker build -t local/atheris .
+# $ docker run -ti --rm local/atheris \
+#   -v <PathToTheSourceFilesFolder>:/usr/src/app \
+#   -it python /usr/src/app/<YourSourceFile>
+#
+FROM python:3.8-buster
 
 # Default to the development branch of LLVM (currently 12)
 # User can override this to a stable branch (like 10 or 11)
@@ -42,13 +64,15 @@ RUN set -eux; \
     chmod -f +x /usr/lib/llvm-${LLVM_VERSION}/bin/* && \
     update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-${LLVM_VERSION} 999 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 999 && \
-    CLANG_BIN="/usr/bin/clang" pip install atheris hypothesis && \
+    pip install atheris hypothesis && \
     rm -rf /var/lib/apt/lists/*
 
-# Build from the sources
+# Uncomment this to build from the sources
 # WORKDIR /usr/src/atheris
 # COPY . .
 # RUN set -eux; \
 #     CLANG_BIN="/usr/bin/clang"  pip install -e .
 ### Test build from sources
 ###  python example_fuzzers/fuzzing_example.py
+
+WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM python:3.8-buster
+# Example command:
+# $ git clone https://github.com/google/atheris.git
+# $ cd atheris
+# $ sudo docker build -t local/atheris .
+# $ sudo docker run -ti --rm local/atheris 
 
 # Default to the development branch of LLVM (currently 12)
 # User can override this to a stable branch (like 10 or 11)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.8-buster
+
+# Default to the development branch of LLVM (currently 12)
+# User can override this to a stable branch (like 10 or 11)
+ARG LLVM_VERSION=12
+ARG IMAGE_VERSION=0.0.0-local
+ARG BUILD_DATE=unknown
+ARG COMMIT_HASH=unknown
+
+# Configure image labels
+LABEL \
+    org.opencontainers.image.ref.name="google/atheris" \
+    org.opencontainers.image.description="Atheris: A Coverage-Guided, Native Python Fuzzer" \
+    org.opencontainers.image.documentation="https://github.com/google/atheris" \
+    org.opencontainers.image.licenses="Apache License 2.0" \
+    org.opencontainers.image.source="https://github.com/google/atheris" \
+    org.opencontainers.image.title="Atheris" \
+    org.opencontainers.image.url="https://github.com/google/atheris" \
+    org.opencontainers.image.vendor="Google" \
+    org.opencontainers.image.version=$IMAGE_VERSION \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.revision=$COMMIT_HASH
+
+# Install the latest Clang/lld packages from apt.llvm.org
+# Delete all the apt list files at the end
+RUN set -eux; \
+    curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster main" | tee -a /etc/apt/sources.list && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        vim \
+        clang-${LLVM_VERSION} \
+        lld-${LLVM_VERSION} \
+        llvm-${LLVM_VERSION} && \
+    CLANG_BIN="/usr/lib/llvm-12/bin/clang" pip install atheris hypothesis && \
+    rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import sys
 def TestOneInput(data):
   if data == b"bad":
     raise RuntimeError("Badness!")
-    
+
 atheris.Setup(sys.argv, TestOneInput)
 atheris.Fuzz()
 ```
@@ -135,7 +135,7 @@ def ConsumeBytes(count: int)
 ```
 Consume `count` bytes.
 
-  
+
 ```
 def ConsumeUnicode(count: int)
 ```
@@ -255,6 +255,7 @@ input.  For example:
 
 ```
 import atheris
+import sys
 from hypothesis import given, strategies as st
 
 @given(st.from_regex(r"\w+!?", fullmatch=True))
@@ -267,4 +268,3 @@ atheris.Fuzz()
 
 [See here for more details](https://hypothesis.readthedocs.io/en/latest/details.html#use-with-external-fuzzers),
 or [here for what you can generate](https://hypothesis.readthedocs.io/en/latest/data.html).
-


### PR DESCRIPTION
<table>
  <tbody>
    <tr>
      <th>Type</th>
      <td>New Feature</th>
    </tr>
    <tr>
      <th>Issue</th>
      <td>Support build Docker Image</th>
    </tr>
    <tr>
      <th>Change</th>
      <td>Add Dockerfile </th>
    </tr>
  </tbody>
</table>

## Example

```
$ docker build -t local/atheris .
$ docker run -ti --rm local/atheris 
Python 3.8.6 (default, Nov 18 2020, 13:49:49) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import atheris
>>> import sys
>>> from hypothesis import given, strategies as st
>>> 
>>> @given(st.from_regex(r"\w+!?", fullmatch=True))
... def test(string):
...   assert string != "bad"
... 
>>> atheris.Setup(sys.argv, test.hypothesis.fuzz_one_input)
INFO: Configured for Python tracing with opcodes.
['']
>>> atheris.Fuzz()
WARNING: Failed to find function "__sanitizer_acquire_crash_state".
WARNING: Failed to find function "__sanitizer_print_stack_trace".
WARNING: Failed to find function "__sanitizer_set_death_callback".
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 713180454
INFO: Loaded 2 modules   (1024 inline 8-bit counters): 512 [0x55ca41b83ff0, 0x55ca41b841f0), 512 [0x55ca41b84a10, 0x55ca41b84c10), 
INFO: Loaded 2 PC tables (1024 PCs): 512 [0x55ca41bcb330,0x55ca41bcd330), 512 [0x55ca41bcd340,0x55ca41bcf340), 
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
```

## Tested 
I build the image https://hub.docker.com/r/weldpua2008/atheris from the branch



```
$  docker run -ti --rm  -v ${PWD}:/app -w /app/example_fuzzers/json_fuzzer/ local/atheris bash
root@55f3f0c1f18f:/app/example_fuzzers/json_fuzzer# bash ./build_install_ujson.sh 
root@55f3f0c1f18f:/app/example_fuzzers/json_fuzzer# LD_PRELOAD="/usr/lib/llvm-12/lib/clang/12.0.0/lib/linux/libclang_rt.asan-x86_64.so $(python3 -c "import atheris; print(atheris.path())")" python3 ./ujson_fuzzer.py -detect_leaks=0 
WARNING: Coverage symbols are being provided by a library other than libFuzzer. This will result in broken Python code coverage and severely impacted native extension code coverage. Symbols are coming from this library: /usr/lib/llvm-12/lib/clang/12.0.0/lib/linux/libclang_rt.asan-x86_64.so
You can likely resolve this issue by linking libFuzzer into Python directly, and using `atheris_no_libfuzzer` instead of `atheris`. See using_sanitizers.md for details.INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 935762228
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2	INITED ft: 1 corp: 1/1b exec/s: 0 rss: 41Mb

```