### PR TITLE
Tweak readme: syntax-highlight code blocks and explain API design

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Atheris supports Linux (32- and 64-bit) and Mac OS X.
 ### Linux
 
 Atheris relies on libFuzzer, which is distributed with Clang. If you have a sufficiently new version of `clang` on your path, installation is as simple as:
-```
+```bash
 pip install atheris
 ```
 
@@ -21,7 +21,7 @@ Atheris relies on libFuzzer, which is distributed with Clang. However, Apple Cla
 
 ### Installing Against New LLVM
 
-```
+```bash
 # Building LLVM
 git clone https://github.com/llvm/llvm-project.git
 cd llvm-project
@@ -38,14 +38,14 @@ CLANG_BIN="$(pwd)/bin/clang" pip3 install atheris
 
 ### Example:
 
-```
+```python
 import atheris
 import sys
 
 def TestOneInput(data):
   if data == b"bad":
     raise RuntimeError("Badness!")
-    
+
 atheris.Setup(sys.argv, TestOneInput)
 atheris.Fuzz()
 ```
@@ -68,7 +68,7 @@ In order for native fuzzing to be effective, such native extensions must be buil
 
 The mechanics of building with Clang depend on your native extension. However, if your library is built with setuptools (e.g. `pip` and setup.py), the following is often sufficient:
 
-```
+```bash
 CC="/usr/bin/clang" CFLAGS="-fsanitize=fuzzer-no-link" CXX="/usr/bin/clang++" CXXFLAGS="-fsanitize=fuzzer-no-link" pip install .
 ```
 
@@ -86,27 +86,27 @@ Atheris is fully supported by [OSS-Fuzz](https://github.com/google/oss-fuzz), Go
 
 The `atheris` module provides two key functions: `Setup()` and `Fuzz()`.
 
-In your source file, define a fuzzer entry point function, and pass it to atheris.Setup(), along with the fuzzer's arguments (typically sys.argv). Finally, call atheris.Fuzz() to start fuzzing. Here's an example:
+In your source file, define a fuzzer entry point function, and pass it to `atheris.Setup()`, along with the fuzzer's arguments (typically `sys.argv`). Finally, call `atheris.Fuzz()` to start fuzzing. Here's an example:
 
-```
-def Setup(args, callback, [optional arguments...]):
+```python
+def Setup(args, callback, enable_python_coverage=True, enable_python_opcode_coverage=True):
 ```
 
-Configure the Atheris Python Fuzzer. You must call atheris.Setup() before atheris.Fuzz().
+Configure the Atheris Python Fuzzer. You must call `atheris.Setup()` before `atheris.Fuzz()`.
 
 Args:
- - `args`: A list of strings: the process arguments to pass to the fuzzer, typically sys.argv. This argument list may be modified in-place, to remove arguments consumed by the fuzzer.
+ - `args`: A list of strings: the process arguments to pass to the fuzzer, typically `sys.argv`. This argument list may be modified in-place, to remove arguments consumed by the fuzzer.
  - `test_one_input`: your fuzzer's entry point. Must take a single `bytes` argument (`str` in Python 2). This will be repeatedly invoked with a single bytes container.
 
 Optional Args:
  - `enable_python_coverage`: boolean. Controls whether to collect coverage information on Python code. Defaults to `True`. If fuzzing a native extension with minimal Python code, set to `False` for a performance increase.
  - `enable_python_opcode_coverage`: boolean. Controls whether to collect Python opcode trace events. You typically want this enabled. Defaults to `True` on Python 3.8+, and `False` otherwise. Ignored if `enable_python_coverage=False`, or if using a version of Python prior to 3.8.
 
-```
+```python
 def Fuzz():
 ```
 
-This starts the fuzzer. You must have called Setup() before calling this function. This function does not return.
+This starts the fuzzer. You must have called `Setup()` before calling this function. This function does not return.
 
 ### FuzzedDataProvider
 
@@ -114,121 +114,121 @@ Often, a `bytes` object is not convenient input to your code being fuzzed. Simil
 
 You can construct the FuzzedDataProvider with:
 
-```
+```python
 fdp = atheris.FuzzedDataProvider(input_bytes)
 ```
 
 The FuzzedDataProvider then supports the following functions:
 
-```
+```python
 def ConsumeBytes(count: int)
 ```
 Consume `count` bytes.
 
-  
-```
+
+```python
 def ConsumeUnicode(count: int)
 ```
 
 Consume unicode characters. Might contain surrogate pair characters, which according to the specification are invalid in this situation. However, many core software tools (e.g. Windows file paths) support them, so other software often needs to too.
 
-```
+```python
 def ConsumeUnicodeNoSurrogates(count: int)
 ```
 
 Consume unicode characters, but never generate surrogate pair characters.
 
-```
+```python
 def ConsumeString(count: int)
 ```
 
 Alias for `ConsumeBytes` in Python 2, or `ConsumeUnicode` in Python 3.
 
-```
+```python
 def ConsumeInt(int: bytes)
 ```
 
 Consume a signed integer of the specified size (when written in two's complement notation).
 
-```
+```python
 def ConsumeUInt(int: bytes)
 ```
 
 Consume an unsigned integer of the specified size.
 
-```
+```python
 def ConsumeIntInRange(min: int, max: int)
 ```
 
 Consume an integer in the range [`min`, `max`].
 
-```
+```python
 def ConsumeIntList(count: int, bytes: int)
 ```
 
 Consume a list of `count` integers of `size` bytes.
 
-```
+```python
 def ConsumeIntListInRange(count: int, min: int, max: int)
 ```
 
 Consume a list of `count` integers in the range [`min`, `max`].
 
-```
+```python
 def ConsumeFloat()
 ```
 
 Consume an arbitrary floating-point value. Might produce weird values like `NaN` and `Inf`.
 
-```
+```python
 def ConsumeRegularFloat()
 ```
 
 Consume an arbitrary numeric floating-point value; never produces a special type like `NaN` or `Inf`.
 
-```
+```python
 def ConsumeProbability()
 ```
 
 Consume a floating-point value in the range [0, 1].
 
-```
+```python
 def ConsumeFloatInRange(min: float, max: float)
 ```
 
 Consume a floating-point value in the range [`min`, `max`].
 
-```
+```python
 def ConsumeFloatList(count: int)
 ```
 
 Consume a list of `count` arbitrary floating-point values. Might produce weird values like `NaN` and `Inf`.
 
-```
+```python
 def ConsumeRegularFloatList(count: int)
 ```
 
 Consume a list of `count` arbitrary numeric floating-point values; never produces special types like `NaN` or `Inf`.
 
-```
+```python
 def ConsumeProbabilityList(count: int)
 ```
 
 Consume a list of `count` floats in the range [0, 1].
 
-```
+```python
 def ConsumeFloatListInRange(count: int, min: float, max: float)
 ```
 
 Consume a list of `count` floats in the range [`min`, `max`]
 
-```
+```python
 def PickValueInList(l: list)
 ```
 
 Given a list, pick a random value
 
-```
+```python
 def ConsumeBool()
 ```
 
@@ -243,7 +243,7 @@ which describe the inputs to generate, using Hypothesis makes it trivial to repr
 failures found by the fuzzer - including automatically finding a minimal reproducing
 input.  For example:
 
-```
+```python
 import atheris
 from hypothesis import given, strategies as st
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Configure the Atheris Python Fuzzer. You must call `atheris.Setup()` before `ath
 
 Args:
  - `args`: A list of strings: the process arguments to pass to the fuzzer, typically `sys.argv`. This argument list may be modified in-place, to remove arguments consumed by the fuzzer.
+   See [the LibFuzzer docs](https://llvm.org/docs/LibFuzzer.html#options) for a list of such options.
  - `test_one_input`: your fuzzer's entry point. Must take a single `bytes` argument (`str` in Python 2). This will be repeatedly invoked with a single bytes container.
 
 Optional Args:
@@ -108,9 +109,14 @@ def Fuzz():
 
 This starts the fuzzer. You must have called `Setup()` before calling this function. This function does not return.
 
+In many cases `Setup()` and `Fuzz()` could be combined into a single function, but they are
+separated because you may want the fuzzer to consume the command-line arguments it handles
+before passing any remaining arguments to another setup function.
+
 ### FuzzedDataProvider
 
 Often, a `bytes` object is not convenient input to your code being fuzzed. Similar to libFuzzer, we provide a FuzzedDataProvider to translate these bytes into other input forms.
+Alternatively, you can use [Hypothesis](https://hypothesis.readthedocs.io/) as described below.
 
 You can construct the FuzzedDataProvider with:
 


### PR DESCRIPTION
The two commits in this PR respectively

- Add syntax-highlighting to code blocks in the README, using github-flavored markdown  
  (also understood by VS Code and presumably other tools)
- Add a few clarifying sentences about the handling of command-line arguments ("`args` is for LibFuzzer") and explaining the reason for the split `Setup()`/`Fuzz()` API design.  This closes #8 but I'd appreciate a review from @IanPudney as I could be wrong about how it works 😅