### PR TITLE
Link `*san_with_fuzzer.so` with `-ldl`

### DIFF
--- a/setup_utils/merge_libfuzzer_sanitizer.sh
+++ b/setup_utils/merge_libfuzzer_sanitizer.sh
@@ -35,7 +35,7 @@ cp "$sanitizer" "$tmp_sanitizer"
 
 ar d "$tmp_sanitizer" $strip_preinit  # Intentionally not quoted
 
-"$CXX" -Wl,--whole-archive "$libfuzzer" "$tmp_sanitizer" -Wl,--no-whole-archive -lpthread -shared -o "$tmp_merged"
+"$CXX" -Wl,--whole-archive "$libfuzzer" "$tmp_sanitizer" -Wl,--no-whole-archive -lpthread -ldl -shared -o "$tmp_merged"
 
 echo "$tmp_merged"
 exit 0


### PR DESCRIPTION
The `*san_with_fuzzer.so` dynamic libraries include libFuzzer, which requires `libdl.so`. However, in `merge_libfuzzer_sanitizer.sh`, the libraries are not linked with `-ldl`, which means that they can only be preloaded into a binary that itself links in `libdl.so`. While `python` itself does this, shells might not, which can lead to errors when the preload is applied to e.g. a wrapper script that unpacks a packaged Python application and only then invokes `python` itself.

This is fixed by linking `*san_with_fuzzer.so` with `-ldl`.