### PR TITLE
add LDSHARED example to native docs

### DIFF
--- a/native_extension_fuzzing.md
+++ b/native_extension_fuzzing.md
@@ -8,7 +8,7 @@ While this doesn't work for every extension and build system, if you are using
 setuptools, you can typically compile a sanitized extension like this:
 
 ```
-CC="/usr/bin/clang" CFLAGS="-fsanitize=address,fuzzer-no-link" CXX="/usr/bin/clang++" CXXFLAGS="-fsanitize=address,fuzzer-no-link" pip3 install .
+CC="/usr/bin/clang" CFLAGS="-fsanitize=address,fuzzer-no-link" CXX="/usr/bin/clang++" CXXFLAGS="-fsanitize=address,fuzzer-no-link" LDSHARED="/usr/bin/clang -shared" pip3 install .
 ```
 
 Here, `address` means Address Sanitizer. You can also use `undefined` for the


### PR DESCRIPTION
distutils will try to use whichever compiler built the Python 
interpreter unless otherwise specified with `LDSHARED`, and this comes 
up from time to time.