### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,11 @@ If you'd like to examine coverage when running with your corpus, you can do
 that with the following command:
 
 ```
-python3 -m coverage run your_fuzzer.py corpus_dir/* -atheris_runs=$(ls corpus_dir | wc -l)
+python3 -m coverage run your_fuzzer.py corpus_dir/* -atheris_runs=$(( 1 + $(ls corpus_dir | wc -l) ))
 ```
 
 This will cause Atheris to run on each file in `<corpus-dir>`, then exit.
+Note: atheris use empty data first time even the file absences in corpus_dir.
 Importantly, if you leave off the `-atheris_runs=$(ls corpus_dir | wc -l)`, no
 coverage report will be generated.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ python3 -m coverage run your_fuzzer.py corpus_dir/* -atheris_runs=$(( 1 + $(ls c
 ```
 
 This will cause Atheris to run on each file in `<corpus-dir>`, then exit.
-Note: atheris use empty data first time even the file absences in corpus_dir.
+Note: atheris use empty data set as the first input even if there is no empty file in `<corpus_dir>`.
 Importantly, if you leave off the `-atheris_runs=$(ls corpus_dir | wc -l)`, no
 coverage report will be generated.
 


### PR DESCRIPTION
When atheris_runs is set to number of seed files in corpus directory then first time atheris put empty data even the file is absent in corpus dir (atheris 2.0.11).
So, last file (sorted by size ascending) will be skipped with -atheris_runs=$(ls corpus_dir | wc -l)