### PR TITLE
Fix FuzzedDataProvider::ConsumeSmallIntInRange

### DIFF
--- a/src/native/fuzzed_data_provider.cc
+++ b/src/native/fuzzed_data_provider.cc
@@ -252,9 +252,11 @@ int64_t FuzzedDataProvider::ConsumeSmallIntInRange(size_t n, uint64_t range) {
   uint64_t result = 0;
   size_t offset = 0;
 
-  while (offset < n && (range >> offset) > 0 && remaining_bytes_ != 0) {
-    --remaining_bytes_;
-    result = (result << 8) | data_ptr_[remaining_bytes_];
+  while (offset < n && 0 != (range >> offset)) {
+    if (0 != remaining_bytes_){
+      result |= (static_cast<uint64_t>(*data_ptr_) << offset);
+      Advance(1);
+      }
     offset += 8;
   }
 


### PR DESCRIPTION
FuzzedDataProvider:
ConsumeIntInRange invokes ConsumeSmallIntInRange which generated int64 from tail of remained bytes and did not shift the buffer.
Byte order is keep the same. It consumes the same value from saved seeds when the bytes are in end of data.
Some stored seeds might provide different values.