### PR TITLE
Fixed crash due to weird bytecode

### DIFF
--- a/src/instrument_bytecode.py
+++ b/src/instrument_bytecode.py
@@ -309,12 +309,16 @@ class Instrumentor:
 
       elif arg is not None:
         assert offset is not None
+        combined_arg = 0
+        # https://bugs.python.org/issue45757 can cause instruction.arg to be None
+        if instruction.arg is not None:
+          combined_arg = (arg << 8) | instruction.arg # type: ignore[operator]
         instr_list.append(
             Instruction(
                 lineno,
                 offset,
                 instruction.opcode,
-                (arg << 8) | instruction.arg,  # type: ignore[operator]
+                combined_arg,
                 min_size=length))
         arg = None
         offset = None


### PR DESCRIPTION
Without this fix, this code
```python
#!/usr/bin/env python
src="""
def foo():
    return
"""*300 +"""
def foo(a,
        b: str = 'abc'):
    return
"""
with open("mymod.py", "w") as ofile:
    ofile.write(src)
import atheris
with atheris.instrument_imports():
    import mymod
```
crashes with
```
INFO: Instrumenting mymod
Traceback (most recent call last):
  File "/home/volker/Documents/atherisbug/distest.py", line 14, in <module>
    import mymod
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "/home/volker/.local/lib/python3.10/site-packages/atheris/import_hook.py", line 196, in get_code
    return patch_code(code, self._trace_dataflow)
  File "/home/volker/.local/lib/python3.10/site-packages/atheris/instrument_bytecode.py", line 736, in patch_code
    inst = Instrumentor(code)
  File "/home/volker/.local/lib/python3.10/site-packages/atheris/instrument_bytecode.py", line 281, in __init__
    self._build_cfg()
  File "/home/volker/.local/lib/python3.10/site-packages/atheris/instrument_bytecode.py", line 317, in _build_cfg
    (arg << 8) | instruction.arg,  # type: ignore[operator]
TypeError: unsupported operand type(s) for |: 'int' and 'NoneType'
```