### PR TITLE
chore: fix DeprecationWarning for python 3.11 re module

### DIFF
--- a/src/function_hooks.py
+++ b/src/function_hooks.py
@@ -14,9 +14,13 @@
 """Provides Atheris instrumentation hooks for particular functions like regex."""
 
 import re
-import sre_parse
 import sys
 from typing import Set, Any, Pattern, List, Match, Optional, Iterator, Union, Callable, AnyStr
+try:
+  import re._parser as sre_parse
+except ImportError:
+  import sre_parse
+
 
 # mypy does not like the implicit rexport of the constants available in
 # sre_parse, and also does not support ignoring for blocks of code. Rather


### PR DESCRIPTION
I couldn't find any info besides CLA in the CONTRIBUTING, so hopefully this PR is sufficient for you in terms of description, code style, commit name etc.
Using pyenv `3.110b5` python version, I've noticed plenty of `DeprecationWarning` as below:

```
/home/username/.pyenv/versions/3.11.0b5/envs/project/lib/python3.11/site-packages/atheris/function_hooks.py:17: DeprecationWarning: module 'sre_parse' is deprecated
    import sre_parse
``` 

And one of the first links in google lead me to a very similar issue on Hipothesis project: https://github.com/HypothesisWorks/hypothesis/issues/3309

So I've copied it to mitigate said `DeprecationWarning`. If you'd prefer `if` statement checking whether python version is equal or greater than 3.11 in this place instead of `try/except` clause, please let me know.