### PR TITLE
Make use of github actions

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -1,0 +1,30 @@
+name: Builds
+
+on: [push, pull_request]
+
+env:
+  FORCE_COLOR: 1
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: pip3 install PyInstaller
+    - name: Build
+      run: pip3 install .
+    - name: Run tests
+      run: cd src; python -m unittest discover . -p '*_test.py'


### PR DESCRIPTION
This should close #62

It highlights a couple of shortcomings/issues:
- A test is spamming `Hello from crossover` and `Hello from mutator` for no good reasons.
- We've got some warnings that we should fix:
  - `TypeError: exceptions must derive from BaseException` in `atheris/src/custom_mutator_and_crossover_fuzz_test.py:39`
  - `WARNING: Encountered non-handled RegEx op: AT, cannot instrument RegEx`
  - `WARNING: Unsupported RegEx category, cannot instrument RegEx!`
- `RuntimeError: Was foobarbazbiz` should raise a proper message instead of something cryptic.