### PR TITLE
fix: offsets adjustments on backwards jumps

### DIFF
--- a/src/coverage_test.py
+++ b/src/coverage_test.py
@@ -87,6 +87,12 @@ class CoverageTest(unittest.TestCase):
 
     self.assertNotEqual(first_call_set, third_call_set)
 
+  def testWhile(self, trace_branch_mock, trace_cmp_mock,
+                 trace_regex_match_mock):
+    trace_branch_mock.assert_not_called()
+    coverage_test_helper.while_loop(1)
+    trace_branch_mock.assert_called()
+
   def testRegex(self, trace_branch_mock, trace_cmp_mock,
                 trace_regex_match_mock):
     trace_branch_mock.reset_mock()

--- a/src/coverage_test_helper.py
+++ b/src/coverage_test_helper.py
@@ -42,5 +42,10 @@ def cmp_const_less_inverted(a):
   return a < 1
 
 
+def while_loop(a):
+  while a:
+    a -= 1
+
+
 def regex_match(re_obj, a):
   re_obj.match(a)

--- a/src/instrument_bytecode.py
+++ b/src/instrument_bytecode.py
@@ -208,22 +208,15 @@ class Instruction:
     if changed_offset <= old_offset:
       self.offset += size
 
-    if old_reference is not None and not keep_ref:
-      if changed_offset <= old_reference:
-        self.reference += size  # type: ignore[operator]
+    if old_reference is not None:
+      if not keep_ref and changed_offset <= old_reference:
+          self.reference += size  # type: ignore[operator]
 
       if self._is_relative:
-        if self.mnemonic not in REL_REFERENCE_IS_INVERTED and (
-            old_offset < changed_offset <= old_reference
-        ):
-          self.arg = add_bytes_to_jump_arg(self.arg, size)
-        elif self.mnemonic in REL_REFERENCE_IS_INVERTED and (
-            old_offset >= changed_offset >= old_reference
-        ):
-          self.arg = add_bytes_to_jump_arg(self.arg, size)
+        zero = self.offset + self.get_size()
+        self.arg = add_bytes_to_jump_arg(0, abs(self.reference - zero))
       else:
-        if changed_offset <= old_reference:
-          self.arg = add_bytes_to_jump_arg(self.arg, size)
+        self.arg = add_bytes_to_jump_arg(0, self.reference)
 
   def check_state(self) -> None:
     """Asserts that internal state is consistent."""


### PR DESCRIPTION
`Instruction.adjust` was not adjusting `arg` for backwards jump instructions with relative offsets that were marked as keep ref (`reference` should not change, but relative `arg` may still need to be recalculated).

* Replaced conditional updates of `arg` with direct calculation based on new `offset` and `reference`.
* Added test instrumenting a `while` loop that was exposing this issue on python 3.11

Fixes #57 