### PR TITLE
Run the CI on OSX as well

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -36,10 +36,11 @@ jobs:
     - name: Run mypy checks
       run: mypy src/
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-latest", "osx-latest"]
+    runs-on: ${{ matrix.os }}
     needs: [ruff, mypy]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: ["ubuntu-latest", "osx-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
     needs: [ruff, mypy]
     steps:


### PR DESCRIPTION
```
RuntimeError: Failed to find libFuzzer; you may be building using Apple Clang. Apple Clang does not come with libFuzzer.
      Please download and build the latest version of Clang:
          git clone --depth=1 https://github.com/llvm/llvm-project.git
          cd llvm-project
          cmake -DLLVM_ENABLE_PROJECTS='clang;compiler-rt' -G "Unix Makefiles" -S llvm -B build
          NPROC=$(sysctl -n hw.logicalcpu 2>/dev/null || nproc)
          cmake --build build --parallel $NPROC # This step is very slow.
      Then, set $CLANG_BIN="$(pwd)/bin/clang" and run pip again.
      You should use this same Clang for building any Python extensions you plan to fuzz.
```

I'm not sure we want to build clang in the github ci…