### PR TITLE
Revert "Remove some useless imports"

### DIFF
--- a/src/custom_crossover_fuzz_test.py
+++ b/src/custom_crossover_fuzz_test.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
 import unittest
+import zlib
 
 import atheris
 

--- a/src/custom_mutator_and_crossover_fuzz_test.py
+++ b/src/custom_mutator_and_crossover_fuzz_test.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
 import unittest
+import zlib
 
 import atheris
 

--- a/src/custom_mutator_fuzz_test.py
+++ b/src/custom_mutator_fuzz_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
 import unittest
 import zlib
 

--- a/src/fuzz_test.py
+++ b/src/fuzz_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
+import sys
 import time
 import unittest
 import zlib

--- a/src/import_hook.py
+++ b/src/import_hook.py
@@ -25,7 +25,7 @@ from importlib import abc
 from importlib import machinery
 import sys
 import types
-from typing import Set, Optional, Sequence, Union, Any
+from typing import Set, Optional, Sequence, Type, Union, Any
 from .instrument_bytecode import patch_code
 
 _warned_experimental = False


### PR DESCRIPTION
This reverts commit 9d9d503387f955fedfe3307ab8fc2044696e6536.

Reverted removing useless imports, since Google3 needs some of the import statements internally.