### PR TITLE
counters: add missing <cstdint> include

### DIFF
--- a/src/native/counters.cc
+++ b/src/native/counters.cc
@@ -18,6 +18,7 @@
 
 #include <sys/mman.h>
 
+#include <cstdint>
 #include <iostream>
 
 #include "macros.h"


### PR DESCRIPTION
This fixes compiling with GCC 13.2.0, on Ubuntu, on aarch64:
```bash
      aarch64-linux-gnu-gcc -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -DVERSION_INFO='2.2.2' -DATHERIS_MODULE_NAME=core_with_libfuzzer -I/tmp/pip-build-env-uuoaoijj/normal/local/lib/python3.11/dist-packages/pybind11/include -I/usr/include/python3.11 -c src/native/counters.cc -o build/temp.linux-aarch64-cpython-311/src/native/counters.o -DPYBIND11_DETAILED_ERROR_MESSAGES=1 -Wno-attributes -Wno-address -Wno-deprecated-declarations -std=c++14
      src/native/counters.cc:26:6: error: variable or field ‘__sanitizer_cov_8bit_counters_init’ declared void
         26 | void __sanitizer_cov_8bit_counters_init(uint8_t* start, uint8_t* stop);
            |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      src/native/counters.cc:26:41: error: ‘uint8_t’ was not declared in this scope
         26 | void __sanitizer_cov_8bit_counters_init(uint8_t* start, uint8_t* stop);
            |                                         ^~~~~~~
      src/native/counters.cc:24:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
         23 | #include "macros.h"
        +++ |+#include <cstdint>
```