### PR TITLE
Fix compilation on newer compilers

### DIFF
--- a/src/native/counters.cc
+++ b/src/native/counters.cc
@@ -19,6 +19,7 @@
 #include <sys/mman.h>
 
 #include <iostream>
+#include <cstdint>
 
 #include "macros.h"
 


### PR DESCRIPTION
src/native/counters.cc:26:6: error: variable or field '__sanitizer_cov_8bit_counters_init' declared void
   26 | void __sanitizer_cov_8bit_counters_init(uint8_t* start, uint8_t* stop);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/native/counters.cc:26:41: error: 'uint8_t' was not declared in this scope
   26 | void __sanitizer_cov_8bit_counters_init(uint8_t* start, uint8_t* stop);
      |                                         ^~~~~~~
src/native/counters.cc:24:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   23 | #include "macros.h"
  +++ |+#include <cstdint>