### PR TITLE
Explicit export

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -51,3 +51,14 @@ from .utils import path
 def get_hook_dirs() -> List[str]:
   import os  # pylint: disable=g-import-not-at-top
   return [os.path.dirname(__file__)]
+
+__all__ = (
+  "Fuzz",
+  "FuzzedDataProvider",
+  "Mutate",
+  "Setup",
+  "enabled_hooks",
+  "instrument_all",
+  "instrument_func",
+  "instrument_imports",
+)


### PR DESCRIPTION
We get mypy errors because nothing is explicitly exported from this library.

e.g.
```
fuzzers/payload_url.py:22:6: error: Module "atheris" does not explicitly export
attribute "instrument_imports"  [attr-defined]
    with atheris.instrument_imports():
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

This explicitly exports everything mentioned in the README, using `__all__`. The alternative export mechanism is to use `as` syntax on the imports, if the first method is not preferred for any reason.